### PR TITLE
Allow global cache hits by default

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,22 @@
+name: test
+on:
+  workflow_dispatch: null
+  pull_request: null
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install action-validator with asdf
+        uses: asdf-vm/actions/install@v2
+        with:
+          tool_versions: |
+            action-validator 0.5.3
+      - name: Validate action.yaml
+        run: |
+          action-validator --verbose action.yaml

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ jobs:
           make test
 ```
 
-> :information_source: The `GH_TOKEN` environment variable can also be provided directly to the action as a `github-token` input. This is necessary for the action to check for cache hits by default. If you'd prefer to avoid using a token, you can still use [branch-local caching](#branch-local-caching).
+> :information_source: The `GH_TOKEN` environment variable is necessary for the action to check for cache hits by default. If you'd prefer to avoid using a token, you can still use [branch-local caching](#branch-local-caching).
 
 ### Filtering input files
 

--- a/action.yaml
+++ b/action.yaml
@@ -52,7 +52,7 @@ outputs:
 
       Returns 'true' if an entry with the correct key exists in the cache,
       otherwise returns 'false'.
-    value: '${{ inputs.global == 'true' && steps.check-cache.outputs.cache-hit || steps.cache.outputs.cache-hit }}'
+    value: ${{ inputs.global == 'true' && steps.check-cache.outputs.cache-hit || steps.cache.outputs.cache-hit }}
 runs:
   using: composite
   steps:

--- a/action.yaml
+++ b/action.yaml
@@ -31,11 +31,6 @@ inputs:
 
       When set to false, a github token is not necessary.
     default: 'true'
-  github-token:
-    description: |
-      The GitHub token to use for checking cache hits. Not required if
-      global is set to false.
-    default: ''
 outputs:
   sha:
     description: |
@@ -72,12 +67,9 @@ runs:
         touch job-cache.txt
     - id: check-cache
       if: inputs.global == 'true'
-      env:
-        INPUT_GH_TOKEN: ${{ inputs.github-token }}
       name: Check if job previously passed
       shell: bash
       run: |
-        GH_TOKEN="${GH_TOKEN:=${INPUT_GH_TOKEN}}"
         repoName=$(gh repo view --json nameWithOwner | jq -r '.nameWithOwner')
         cacheHit=$(
           gh api \

--- a/action.yaml
+++ b/action.yaml
@@ -39,7 +39,7 @@ outputs:
 
       Returns 'true' if an entry with the correct key exists in the cache,
       otherwise returns 'false'.
-    value: '${{ steps.cache.outputs.cache-hit }}'
+    value: '${{ steps.check-cache.outputs.cache-hit }}'
 runs:
   using: composite
   steps:
@@ -57,6 +57,23 @@ runs:
         echo "sha=${sha256}" >> "${GITHUB_OUTPUT}"
         echo "key=${{ inputs.prefix }}${sha256}" >> "${GITHUB_OUTPUT}"
         touch job-cache.txt
+    - id: check-cache
+      name: Check if job previously passed
+      shell: bash
+      run: |
+        repoName=$(gh repo view --json nameWithOwner | jq -r '.nameWithOwner')
+        cacheHit=$(
+          gh api \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "repos/${repoName}/actions/caches?key="'${{ steps.compute-sha.outputs.key }}' \
+            | jq '.total_count != 0'
+        )
+        echo "cache-hit=${cacheHit}" >> "${GITHUB_OUTPUT}"
+    # This ensures a post-step which populates that cache _after_ other steps
+    # have completed successfully. We don't use the `cache-hit` output from
+    # this step, because it only reports a cache-hit for keys produced on the
+    # current branch.
     - id: cache
       uses: actions/cache@v3
       with:

--- a/action.yaml
+++ b/action.yaml
@@ -23,6 +23,19 @@ inputs:
       Note that it is recommended to include any GitHub workflow files, as
       these can affect job outcomes.
     default: ":/"  # https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-top
+  global:
+    description: |
+      Whether to share the cache between all branches (recommended). If set to
+      false, will only check for previous passes on the current branch, the
+      base branch (if a PR), and the repository's default branch.
+
+      When set to false, a github token is not necessary.
+    default: 'true'
+  github-token:
+    description: |
+      The GitHub token to use for checking cache hits. Not required if
+      global is set to false.
+    default: ''
 outputs:
   sha:
     description: |
@@ -39,7 +52,7 @@ outputs:
 
       Returns 'true' if an entry with the correct key exists in the cache,
       otherwise returns 'false'.
-    value: '${{ steps.check-cache.outputs.cache-hit }}'
+    value: '${{ inputs.global == 'true' && steps.check-cache.outputs.cache-hit || steps.cache.outputs.cache-hit }}'
 runs:
   using: composite
   steps:
@@ -58,9 +71,13 @@ runs:
         echo "key=${{ inputs.prefix }}${sha256}" >> "${GITHUB_OUTPUT}"
         touch job-cache.txt
     - id: check-cache
+      if: inputs.global == 'true'
+      env:
+        INPUT_GH_TOKEN: ${{ inputs.github-token }}
       name: Check if job previously passed
       shell: bash
       run: |
+        GH_TOKEN="${GH_TOKEN:=${INPUT_GH_TOKEN}}"
         repoName=$(gh repo view --json nameWithOwner | jq -r '.nameWithOwner')
         cacheHit=$(
           gh api \
@@ -70,10 +87,6 @@ runs:
             | jq '.total_count != 0'
         )
         echo "cache-hit=${cacheHit}" >> "${GITHUB_OUTPUT}"
-    # This ensures a post-step which populates that cache _after_ other steps
-    # have completed successfully. We don't use the `cache-hit` output from
-    # this step, because it only reports a cache-hit for keys produced on the
-    # current branch.
     - id: cache
       uses: actions/cache@v3
       with:


### PR DESCRIPTION
This PR modifies the cache lookup logic, to attempt to side-step [restrictions which prevent matching caches generated by other branches](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache).

We only need to check that the cache key exists, so we can use the regular REST API, which I hope avoids these restrictions.
